### PR TITLE
Use I²C repeated start condition in WriteRead trait

### DIFF
--- a/src/drivers/i2c.rs
+++ b/src/drivers/i2c.rs
@@ -159,7 +159,6 @@ where
     }
 
     fn write_without_stop(&mut self, addr: u8, bytes: &[u8]) -> Result<()> {
-        // use cortex_m_semihosting::dbg;
         self.return_on_error()?;
 
         // Write the slave address with the RW bit set to 0 to the master data register MSTDAT.


### PR DESCRIPTION
The embedded_hal WriteRead trait contract requires that a repeated start is used between the write and read parts of the transaction. This is not the same thing as sending a write transaction followed by a read transaction and a "stop start" sequence between them.

For example, some devices such as the NXP MMA8652FC 3-axis accelerometer will not see successive write and read transactions as a combined one unless the repeated start is used.

This has been tested on a LPCXpresso board from NXP, which includes the above-mentionned accelerometer. With this patch, the accelerometer and the other I²C peripheral on the board (an audio codec) can both be properly addressed.
