### PR TITLE
Implement rand_core::RngCore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ nb = "1"
 cortex-m-rtic = { version = "0.5.1", optional = true }
 # littlefs2 = { path = "../littlefs2", optional = true }
 littlefs2 = { git = "https://github.com/nickray/littlefs2", branch = "closures-instead-of-ub", optional = true }
+rand_core = "0.5.1"
 usb-device = "0.2.3"
 usbd-serial = "0.1.0"
 vcell = "0.1.2"

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -6,8 +6,8 @@ use cortex_m::asm;
 use cortex_m_rt::entry;
 use cortex_m_semihosting::dbg;
 
-use embedded_hal::blocking::rng::Read;
 use lpc55_hal as hal;
+use hal::traits::rand_core::RngCore;
 
 #[entry]
 fn main() -> ! {
@@ -43,7 +43,7 @@ fn main() -> ! {
     // HAL access
     let mut rng = hal::Rng::from(dp.RNG).enabled(&mut syscon);
     let mut random_bytes = [0u8; 5];
-    rng.read(&mut random_bytes).expect("RNG failure");
+    rng.fill_bytes(&mut random_bytes);
     dbg!(random_bytes);
 
     dbg!(rng.module_id());

--- a/src/drivers/rng.rs
+++ b/src/drivers/rng.rs
@@ -1,4 +1,7 @@
-use crate::traits::wg::blocking::rng;
+use crate::traits::{
+    rand_core,
+    wg::blocking::rng,
+};
 
 use crate::typestates::{
     init_state,
@@ -26,5 +29,23 @@ impl rng::Read for Rng<init_state::Enabled> {
         }
 
         Ok(())
+    }
+}
+
+impl rand_core::RngCore for Rng<init_state::Enabled> {
+    fn next_u32(&mut self) -> u32 {
+        self.get_random_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        rand_core::impls::next_u64_via_u32(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        rand_core::impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        Ok(self.fill_bytes(dest))
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,6 +11,8 @@ pub use digest;
 // Would be worth being more explicit.
 pub use embedded_hal as wg;
 
+pub use rand_core;
+
 // TODO: Add more as needed,
 // - internal
 // - specific (CASPER, PUF, etc.)


### PR DESCRIPTION
Hopefully, outcome of https://github.com/rust-embedded/embedded-hal/issues/128 is to remove the embedded WG's RNG trait; then we would remove its implementation.