### PR TITLE
Vendored RTIC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,15 @@ vcell = "0.1"
 void = { version = "1", default-features = false }
 
 # optional dependencies
-cortex-m-rtic = { version = "0.5", optional = true }
+# cortex-m-rtic = { version = "0.5", optional = true }
+lpc55-rtic = { version = "0.5", optional = true }
 littlefs2 = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 aes-soft = "0.6"
 cortex-m-rt = "0.6"
-cortex-m-rtic = "0.5"
+# cortex-m-rtic = "0.5"
+lpc55-rtic = "0.5"
 cortex-m-semihosting = "0.3"
 heapless = "0.6"
 panic-halt  = "0.2"
@@ -50,7 +52,7 @@ usbd-serial = "0.1"
 default = ["rt"]
 littlefs = ["littlefs2"]
 rt = ["lpc55-pac/rt"]
-rtic-peripherals = ["cortex-m-rtic"]
+rtic-peripherals = ["lpc55-rtic"]
 # no longer a HAL feature, just for the usb examples
 highspeed-usb-example = []
 


### PR DESCRIPTION
It's unfortunate, but RTIC is busy with API changes, meanwhile we'd like to get unstuck on cortex-m, generic-array and heapless versions. The only use of RTIC in this HAL is to offer a RTIC-ized "peripherals" object (with SysTick removed). And the constructor for this takes CorePeripherals from RTIC, which is on cortex-m 0.6 in published versions.

The intent is to remove this vendored RTIC and bump HAL to 0.2 once RTIC 0.6 is out.