### PR TITLE
Minor bumps; unfortunately no generic-array removal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ void = { version = "1", default-features = false }
 # optional dependencies
 # cortex-m-rtic = { version = "0.5", optional = true }
 lpc55-rtic = { version = "0.5.7", optional = true }
-littlefs2 = { version = "0.2.1", optional = true }
+littlefs2 = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 aes = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55-hal"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 description   = "Hardware Abstraction Layer (HAL) for the NXP LPC55S6x ARM Cortex-33 microcontrollers"
 repository = "https://github.com/nickray/lpc55-hal"
@@ -21,7 +21,7 @@ cipher = "0.3"
 cortex-m = "0.7"
 digest = "0.9"
 embedded-hal = { version = "0.2", features = ["unproven"] }
-embedded-time = "0.10.1"
+embedded-time = "0.12"
 generic-array = "0.14.2"
 lpc55-pac = "0.4"
 nb = "1"
@@ -36,12 +36,12 @@ lpc55-rtic = { version = "0.5.7", optional = true }
 littlefs2 = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
-aes-soft = "0.6"
+aes = "0.7"
 cortex-m-rt = "0.6"
 # cortex-m-rtic = "0.5"
 lpc55-rtic = "0.5"
 cortex-m-semihosting = "0.3"
-heapless = "0.6"
+heapless = "0.7"
 panic-halt  = "0.2"
 panic-semihosting = { version = "0.5", features = ["jlink-quirks"] }
 rtt-target = { version = "0.3", features = ["cortex-m"] }

--- a/examples/aes.rs
+++ b/examples/aes.rs
@@ -14,7 +14,7 @@ use hal::prelude::*;
 #[allow(unused_imports)]
 use lpc55_hal as hal;
 
-use aes_soft::cipher::{BlockCipher, NewBlockCipher};
+use aes::cipher::NewBlockCipher;
 use hal::traits::cipher::{BlockDecrypt, BlockEncrypt};
 
 use generic_array::GenericArray;
@@ -37,7 +37,7 @@ fn main() -> ! {
     // via software
     //
     let mut sw_block = block.clone();
-    let cipher = aes_soft::Aes256::new(&key);
+    let cipher = aes::Aes256::new(&key);
 
     let (sw_cyc_enc, _) = hal::count_cycles(|| {
         cipher.encrypt_block(&mut sw_block);

--- a/examples/late.rs
+++ b/examples/late.rs
@@ -14,8 +14,6 @@
 use cortex_m_semihosting::hprintln;
 use hal::raw::Interrupt;
 use heapless::{
-    consts::*,
-    i,
     spsc::{Consumer, Producer, Queue},
 };
 use lpc55_hal as hal;
@@ -25,13 +23,13 @@ use panic_semihosting as _;
 const APP: () = {
     // Late resources
     struct Resources {
-        p: Producer<'static, u32, U4>,
-        c: Consumer<'static, u32, U4>,
+        p: Producer<'static, u32, 4>,
+        c: Consumer<'static, u32, 4>,
     }
 
     #[init]
     fn init(_: init::Context) -> init::LateResources {
-        static mut Q: Queue<u32, U4> = Queue(i::Queue::new());
+        static mut Q: Queue<u32, 4> = Queue::new();
 
         let (p, c) = Q.split();
 

--- a/src/drivers/flash.rs
+++ b/src/drivers/flash.rs
@@ -2,17 +2,13 @@ use core::convert::TryInto;
 // use cortex_m_semihosting::hprintln;
 
 use crate::{
-    peripherals::{
-        flash::Flash,
-    },
+    peripherals::flash::Flash,
     typestates::init_state::Enabled,
-    traits::{
-        flash::{
-            Error,
-            Result,
-            Read,
-            WriteErase,
-        },
+    traits::flash::{
+        Error,
+        Result,
+        Read,
+        WriteErase,
     },
 };
 
@@ -20,9 +16,6 @@ pub use generic_array::{
     GenericArray,
     typenum::{U16, U512},
 };
-
-#[cfg(feature = "littlefs")]
-use generic_array::typenum::{U256, U1022};
 
 // one physical word of Flash consists of 128 bits (or 4 u32, or 16 bytes)
 // one page is 32 physical words, or 128 u32s, or 512 bytes)
@@ -358,12 +351,6 @@ pub mod littlefs_params {
 
     pub type CACHE_SIZE = U512;
     pub type LOOKAHEADWORDS_SIZE = U16;
-    /// TODO: We can't actually be changed currently
-    pub type FILENAME_MAX_PLUS_ONE = U256;
-    pub type PATH_MAX_PLUS_ONE = U256;
-    pub const FILEBYTES_MAX: usize = littlefs2::ll::LFS_FILE_MAX as _;
-    /// TODO: We can't actually be changed currently
-    pub type ATTRBYTES_MAX = U1022;
 }
 
 #[cfg(feature = "littlefs")]
@@ -413,10 +400,6 @@ macro_rules! littlefs2_filesystem {
 
             type CACHE_SIZE = $crate::drivers::flash::littlefs_params::CACHE_SIZE;
             type LOOKAHEADWORDS_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEADWORDS_SIZE;
-            type FILENAME_MAX_PLUS_ONE = $crate::drivers::flash::littlefs_params::FILENAME_MAX_PLUS_ONE;
-            type PATH_MAX_PLUS_ONE = $crate::drivers::flash::littlefs_params::PATH_MAX_PLUS_ONE;
-            const FILEBYTES_MAX: usize = $crate::drivers::flash::littlefs_params::FILEBYTES_MAX;
-            type ATTRBYTES_MAX = $crate::drivers::flash::littlefs_params::ATTRBYTES_MAX;
 
 
             fn read(&self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {
@@ -501,10 +484,6 @@ macro_rules! littlefs2_prince_filesystem {
 
             type CACHE_SIZE = $crate::drivers::flash::littlefs_params::CACHE_SIZE;
             type LOOKAHEADWORDS_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEADWORDS_SIZE;
-            type FILENAME_MAX_PLUS_ONE = $crate::drivers::flash::littlefs_params::FILENAME_MAX_PLUS_ONE;
-            type PATH_MAX_PLUS_ONE = $crate::drivers::flash::littlefs_params::PATH_MAX_PLUS_ONE;
-            const FILEBYTES_MAX: usize = $crate::drivers::flash::littlefs_params::FILEBYTES_MAX;
-            type ATTRBYTES_MAX = $crate::drivers::flash::littlefs_params::ATTRBYTES_MAX;
 
 
             fn read(&self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {


### PR DESCRIPTION
If we publish this (mainly some embedded-time niceties), unfortunately it's a breaking change (e.g. to the `solo2` component crates).
It seems embedded-time is having *another* release soon, let's maybe wait for this before inflicting the breaking bump here.