### PR TITLE
Bump littlefs2 to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ void = { version = "1", default-features = false }
 # optional dependencies
 # cortex-m-rtic = { version = "0.5", optional = true }
 lpc55-rtic = { version = "0.5.7", optional = true }
-littlefs2 = { version = "0.3.1", optional = true }
+littlefs2 = { version = "0.4", optional = true }
 
 [dev-dependencies]
 aes = "0.7"

--- a/src/drivers/flash.rs
+++ b/src/drivers/flash.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub use generic_array::{
     GenericArray,
-    typenum::{U16, U512},
+    typenum::{U16, U512, U8},
 };
 
 // one physical word of Flash consists of 128 bits (or 4 u32, or 16 bytes)
@@ -350,7 +350,7 @@ pub mod littlefs_params {
     pub const BLOCK_CYCLES: isize = -1;
 
     pub type CACHE_SIZE = U512;
-    pub type LOOKAHEADWORDS_SIZE = U16;
+    pub type LOOKAHEAD_SIZE = U8;
 }
 
 #[cfg(feature = "littlefs")]
@@ -399,10 +399,10 @@ macro_rules! littlefs2_filesystem {
             const BLOCK_CYCLES: isize = $crate::drivers::flash::littlefs_params::BLOCK_CYCLES;
 
             type CACHE_SIZE = $crate::drivers::flash::littlefs_params::CACHE_SIZE;
-            type LOOKAHEADWORDS_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEADWORDS_SIZE;
+            type LOOKAHEAD_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEAD_SIZE;
 
 
-            fn read(&self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {
+            fn read(&mut self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {
                 <$crate::drivers::flash::FlashGordon as $crate::traits::flash::Read<$crate::drivers::flash::U16>>
                     ::read(&self.flash_gordon, Self::BASE_OFFSET + off, buf);
                 Ok(buf.len())
@@ -483,10 +483,10 @@ macro_rules! littlefs2_prince_filesystem {
             const BLOCK_CYCLES: isize = $crate::drivers::flash::littlefs_params::BLOCK_CYCLES;
 
             type CACHE_SIZE = $crate::drivers::flash::littlefs_params::CACHE_SIZE;
-            type LOOKAHEADWORDS_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEADWORDS_SIZE;
+            type LOOKAHEAD_SIZE = $crate::drivers::flash::littlefs_params::LOOKAHEAD_SIZE;
 
 
-            fn read(&self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {
+            fn read(&mut self, off: usize, buf: &mut [u8]) -> LfsResult<usize> {
                 self.prince.enable_region_2_for(||{
                     let flash: *const u8 = (Self::BASE_OFFSET + off) as *const u8;
                     for i in 0 .. buf.len() {


### PR DESCRIPTION
We should double-check which lookahead size we really want to use.