### PR TITLE
Remove unnecessary as_ref call

### DIFF
--- a/src/drivers/sha.rs
+++ b/src/drivers/sha.rs
@@ -128,7 +128,7 @@ impl<Size: OutputSize> Sha<'_, Size> {
     fn process_block(peripheral: &mut Hashcrypt<Enabled>, input: &GenericArray<u8, BlockSize>) {
         // input must be word-aligned
         let input: Aligned<A4, GenericArray<u8, BlockSize>> = Aligned(input.clone());
-        let addr: u32 = &input.as_ref()[0] as *const _ as _;
+        let addr: u32 = &input[0] as *const _ as _;
         assert_eq!(addr & 0x3, 0);
         while peripheral.raw.status.read().waiting().is_not_waiting() {
             continue;


### PR DESCRIPTION
This can otherwise cause a compilation error.