### PR TITLE
Add fix for HS ZLP NYET bug

### DIFF
--- a/src/drivers/usbd.rs
+++ b/src/drivers/usbd.rs
@@ -137,7 +137,13 @@ where
 
             match ep_dir {
                 UsbDirection::Out if !ep.is_out_buf_set() => {
-                    let size = max_packet_size;
+                    // Add one to only EP0 out buffer's size in order to prevent
+                    // the device from responding with NYET after receiving a ZLP
+                    let size = if index == 0 {
+                        max_packet_size + 1
+                    } else {
+                        max_packet_size
+                    };
                     let buffer = self.ep_allocator.allocate_buffer(size as _)?;
                     ep.set_out_buf(buffer);
                     debug_assert!(ep.is_out_buf_set());


### PR DESCRIPTION
Fix bug where when acting as a HS device, it would respond to ZLPs with a NYET. Linux accepts this, but windows doesn't, and it is not an allowed action according to the USB spec. The fix is based off of the LPC55 SDK provided by NXP, and it increases the buffer size of EP0 OUT by one