### PR TITLE
Fix needless_range_loop lints

### DIFF
--- a/src/drivers/touch.rs
+++ b/src/drivers/touch.rs
@@ -296,9 +296,9 @@ where
         let results = unsafe { &mut RESULTS };
         // match button {
         // buttons::ButtonTop => {
-        for i in 0..RESULTS_LEN {
-            if (results[i] & (0xf << 24)) == ((channel as u32) << 24) {
-                results[i] = (results[i] & (!0xffff))
+        for item in results {
+            if (*item & (0xf << 24)) == ((channel as u32) << 24) {
+                *item = (*item & (!0xffff))
                     | (self.threshold[(channel as usize) - 3] as i32 + offset) as u32;
             }
         }
@@ -381,7 +381,9 @@ where
         let mut streak = 0u32;
 
         match ctype {
-            Compare::AboveThreshold => {
+            Compare::AboveThreshold =>
+            {
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..(40 - AVERAGES) {
                     if filtered[i] > self.threshold[(5 - bufsel) as usize] {
                         streak += 1;
@@ -394,7 +396,9 @@ where
                     }
                 }
             }
-            Compare::BelowThreshold => {
+            Compare::BelowThreshold =>
+            {
+                #[allow(clippy::needless_range_loop)]
                 for i in 0..(40 - AVERAGES) {
                     if filtered[i] < self.threshold[(5 - bufsel) as usize] {
                         streak += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod time;
 pub mod traits;
 
 pub mod typestates;
+use core::ptr::copy_nonoverlapping;
+
 pub use typestates::init_state::Enabled;
 
 pub mod peripherals;
@@ -502,8 +504,8 @@ pub fn chip_revision() -> &'static str {
 pub fn uuid() -> [u8; 16] {
     const UUID: *const u8 = 0x0009_FC70 as _;
     let mut uuid: [u8; 16] = [0; 16];
-    for i in 0..16 {
-        uuid[i] = unsafe { *UUID.offset(i as isize) };
+    unsafe {
+        copy_nonoverlapping(UUID, uuid.as_mut_ptr(), 16);
     }
     uuid
 }

--- a/src/peripherals/pfr.rs
+++ b/src/peripherals/pfr.rs
@@ -1,6 +1,7 @@
 use core::result::Result;
 // use cortex_m_semihosting::{heprint,heprintln};
 use crate::{drivers::clocks::Clocks, typestates::init_state};
+use core::ptr::copy_nonoverlapping;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum KeyType {
@@ -333,6 +334,7 @@ impl Pfr<init_state::Enabled> {
     /// returns previous versions of the CFPA page (not seen on scratch, ping, or pong pages).
     /// This method always returns the most recently updated Cfpa from ping or pong pages.
     pub fn read_latest_cfpa(&mut self) -> Result<Cfpa, u32> {
+        use core::ptr::copy_nonoverlapping;
         let mut cfpa_bytes = [0u32; 128];
 
         let ping_ptr = (0x0009_DE00 + 512) as *const u32;
@@ -347,8 +349,8 @@ impl Pfr<init_state::Enabled> {
             pong_ptr
         };
 
-        for i in 0..128 {
-            cfpa_bytes[i] = unsafe { *cfpa_ptr.offset(i as isize) };
+        unsafe {
+            copy_nonoverlapping(cfpa_ptr, cfpa_bytes.as_mut_ptr(), 128);
         }
 
         let cfpa: &Cfpa = unsafe { core::mem::transmute(cfpa_bytes.as_ptr()) };
@@ -360,8 +362,8 @@ impl Pfr<init_state::Enabled> {
         let mut cfpa_bytes = [0u32; 128];
 
         const CFPA_PTR: *const u32 = (0x0009_DE00 + 512) as *const u32;
-        for i in 0..128 {
-            cfpa_bytes[i] = unsafe { *CFPA_PTR.offset(i as isize) };
+        unsafe {
+            copy_nonoverlapping(CFPA_PTR, cfpa_bytes.as_mut_ptr(), 128);
         }
 
         let cfpa: &Cfpa = unsafe { core::mem::transmute(cfpa_bytes.as_ptr()) };
@@ -373,8 +375,8 @@ impl Pfr<init_state::Enabled> {
         let mut cfpa_bytes = [0u32; 128];
 
         const CFPA_PTR: *const u32 = (0x0009_DE00 + 512 + 512) as *const u32;
-        for i in 0..128 {
-            cfpa_bytes[i] = unsafe { *CFPA_PTR.offset(i as isize) };
+        unsafe {
+            copy_nonoverlapping(CFPA_PTR, cfpa_bytes.as_mut_ptr(), 128);
         }
 
         let cfpa: &Cfpa = unsafe { core::mem::transmute(cfpa_bytes.as_ptr()) };

--- a/src/peripherals/puf.rs
+++ b/src/peripherals/puf.rs
@@ -117,9 +117,7 @@ impl<T> Puf<init_state::Enabled<T>> {
         assert!(key_size >= 64);
         assert!(key_index < 16);
 
-        for i in 0..key_code.len() {
-            key_code[i] = 0;
-        }
+        key_code.fill(0);
 
         self.raw
             .keysize
@@ -166,9 +164,7 @@ impl Puf<init_state::Enabled> {
             return Err(Error::NotAllowed);
         }
 
-        for i in 0..ac_buffer.len() {
-            ac_buffer[i] = 0;
-        }
+        ac_buffer.fill(0);
 
         self.raw.ctrl.write(|w| w.enroll().set_bit());
 


### PR DESCRIPTION
Use copy_nonoverlapping instead when it makes sense

Made into it's own PR separate from the main clippy warnings PR because it's not as trivially correct so it needs proper review.