### PR TITLE
Document MSRV and check it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,16 @@ jobs:
         run: cargo build --verbose --examples --target ${{ matrix.target }}
         if: matrix.target != 'x86_64-unknown-linux-gnu'
 
+  build-msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.74"
+          override: true
+
+      - name: Build
+        run: cargo build --all-features --target x86_64-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
--
+- Document the MSRV 1.74
 
 ## [v0.4.1](https://github.com/lpc55/lpc55-hal/releases/tag/0.4.1) - 2025-02-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["no-std", "cortex-m", "nxp", "lpc", "embedded-hal-impl"]
 categories = ["embedded", "no-std"]
 authors = ["Nicolas Stalder <n@stalder.io>", "Conor Patrick <conorpp94@gmail.com>", "Hanno Braun <hanno@braun-robotics.com>"]
 build = "build.rs"
+rust-version = "1.74"
 
 [package.metadata.docs.rs]
 targets = []

--- a/src/peripherals/pfr.rs
+++ b/src/peripherals/pfr.rs
@@ -1,7 +1,7 @@
 use core::result::Result;
 // use cortex_m_semihosting::{heprint,heprintln};
 use crate::{drivers::clocks::Clocks, typestates::init_state};
-use core::ptr::copy_nonoverlapping;
+use core::{mem::size_of, ptr::copy_nonoverlapping};
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum KeyType {
@@ -342,7 +342,6 @@ impl Pfr<init_state::Enabled> {
     /// returns previous versions of the CFPA page (not seen on scratch, ping, or pong pages).
     /// This method always returns the most recently updated Cfpa from ping or pong pages.
     pub fn read_latest_cfpa(&mut self) -> Result<Cfpa, u32> {
-        use core::ptr::copy_nonoverlapping;
         let mut cfpa_bytes = [0u32; 128];
 
         let ping_ptr = (0x0009_DE00 + 512) as *const u32;


### PR DESCRIPTION
Our MSRV is 1.74 due to the littlefs2 dependency. This patch adds it explicitly to Cargo.toml and adds a check for it to the CI. This also fixes the CI because clippy no longer requests the usage of functions added in newer versions of Rust.