### PR TITLE
fix: high-speed interrupt endpoint initialization fix

### DIFF
--- a/src/drivers/usbd/endpoint.rs
+++ b/src/drivers/usbd/endpoint.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::cmp::min;
 
 use core::marker::PhantomData;
@@ -6,7 +7,7 @@ use cortex_m::interrupt::{CriticalSection, Mutex};
 
 use usb_device::{endpoint::EndpointType, Result, UsbError};
 
-use crate::traits::usb::Usb;
+use crate::traits::usb::{Usb, UsbSpeed};
 use crate::typestates::init_state;
 
 use super::{
@@ -21,6 +22,9 @@ where
     out_buf: Option<Mutex<EndpointBuffer>>,
     setup_buf: Option<Mutex<EndpointBuffer>>,
     in_buf: Option<Mutex<EndpointBuffer>>,
+    // TR is one-shot and is consumed when each direction is first armed.
+    out_toggle_reset: Mutex<Cell<bool>>,
+    in_toggle_reset: Mutex<Cell<bool>>,
     ep_type: Option<EndpointType>,
     index: u8,
     pub(crate) _marker: PhantomData<USB>,
@@ -36,6 +40,8 @@ where
             out_buf: None,
             setup_buf: None,
             in_buf: None,
+            out_toggle_reset: Mutex::new(Cell::new(false)),
+            in_toggle_reset: Mutex::new(Cell::new(false)),
             ep_type: None,
             index,
             _marker: PhantomData,
@@ -80,6 +86,7 @@ where
         let addroff = self.buf_addroff(buf);
         let len = buf.capacity() as u16;
         let i = self.index as usize;
+        let toggle_reset = self.out_toggle_reset.borrow(cs).replace(false);
 
         epl.eps[i].ep_out[0].modify(|_, w| {
             w.nbytes::<USB>()
@@ -92,6 +99,8 @@ where
                 .enabled() // technically, marked as R (for reserved?) for EP0
                 .s()
                 .not_stalled()
+                .tr()
+                .bit(toggle_reset)
         });
     }
 
@@ -192,6 +201,46 @@ where
         usb.intstat.write(|w| unsafe { w.bits(!0) });
         debug_assert!(usb.intstat.read().bits() == 0);
 
+        if self.index != 0 {
+            // The high-speed controller uses these bits to distinguish bulk
+            // endpoints from periodic endpoints and to initialize their data
+            // toggle.  Leaving the reset values here makes interrupt OUT
+            // transfers fail as soon as the device enumerates at high speed.
+            let (endpoint_type, toggle_value) = match (USB::SPEED, ep_type) {
+                (UsbSpeed::HighSpeed, EndpointType::Interrupt) => (true, true),
+                (_, EndpointType::Isochronous) => (true, false),
+                _ => (false, false),
+            };
+            let i = self.index as usize;
+
+            if self.is_out_buf_set() {
+                self.out_toggle_reset.borrow(cs).set(true);
+                epl.eps[i].ep_out[0].modify(|_, w| {
+                    w.d()
+                        .disabled()
+                        .t()
+                        .bit(endpoint_type)
+                        .rftv()
+                        .bit(toggle_value)
+                        .tr()
+                        .bit(false)
+                });
+            }
+            if self.is_in_buf_set() {
+                self.in_toggle_reset.borrow(cs).set(true);
+                epl.eps[i].ep_in[0].modify(|_, w| {
+                    w.d()
+                        .disabled()
+                        .t()
+                        .bit(endpoint_type)
+                        .rftv()
+                        .bit(toggle_value)
+                        .tr()
+                        .bit(false)
+                });
+            }
+        }
+
         self.reset_out_buf(cs, epl);
         if self.index == 0 {
             self.reset_setup_buf(cs, epl);
@@ -238,6 +287,7 @@ where
                 return Err(UsbError::WouldBlock);
             }
             in_buf.write(buf);
+            let toggle_reset = self.in_toggle_reset.borrow(cs).replace(false);
             epl.eps[i].ep_in[0].modify(|_, w| {
                 w.nbytes::<USB>()
                     .bits(buf.len() as u16)
@@ -247,6 +297,8 @@ where
                     .enabled()
                     .s()
                     .not_stalled()
+                    .tr()
+                    .bit(toggle_reset)
                     .a()
                     .active()
             });
@@ -296,12 +348,15 @@ where
             unsafe { usb.intstat.write(|w| w.bits(ep_out_mask)) };
 
             // self.reset_out_buf(cs, epl);
+            let toggle_reset = self.out_toggle_reset.borrow(cs).replace(false);
             epl.eps[i].ep_out[0].modify(
                 |_, w| {
                     w.nbytes::<USB>()
                         .bits(out_buf.capacity() as u16)
                         .addroff::<USB>()
                         .bits(self.buf_addroff(out_buf))
+                        .tr()
+                        .bit(toggle_reset)
                         .a()
                         .active()
                 }, // .d().enabled()

--- a/src/drivers/usbd/endpoint_registers.rs
+++ b/src/drivers/usbd/endpoint_registers.rs
@@ -333,6 +333,34 @@ pub mod epr {
         }
     }
 
+    pub struct _RFTVW<'a> {
+        w: &'a mut W,
+    }
+    impl<'a> _RFTVW<'a> {
+        #[inline]
+        pub fn bit(self, value: bool) -> &'a mut W {
+            const MASK: bool = true;
+            const OFFSET: u8 = 27;
+            self.w.bits &= !((MASK as u32) << OFFSET);
+            self.w.bits |= ((value & MASK) as u32) << OFFSET;
+            self.w
+        }
+    }
+
+    pub struct _TRW<'a> {
+        w: &'a mut W,
+    }
+    impl<'a> _TRW<'a> {
+        #[inline]
+        pub fn bit(self, value: bool) -> &'a mut W {
+            const MASK: bool = true;
+            const OFFSET: u8 = 28;
+            self.w.bits &= !((MASK as u32) << OFFSET);
+            self.w.bits |= ((value & MASK) as u32) << OFFSET;
+            self.w
+        }
+    }
+
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub enum SR {
         NotStalled,
@@ -704,16 +732,16 @@ pub mod epr {
         pub fn t(&mut self) -> _TW<'_> {
             _TW { w: self }
         }
-        // #[doc = "Bit 27 - Rate Feedback mode / Toggle Value"]
-        // #[inline]
-        // pub fn rftv(&self) -> _RFTVW {
-        //     _RFTVW { w: self }
-        // }
-        // #[doc = "Bit 28 - Toggle reset"]
-        // #[inline]
-        // pub fn tr(&self) -> _TRW {
-        //     _TRW { w: self }
-        // }
+        #[doc = "Bit 27 - Rate Feedback mode / Toggle Value"]
+        #[inline]
+        pub fn rftv(&mut self) -> _RFTVW<'_> {
+            _RFTVW { w: self }
+        }
+        #[doc = "Bit 28 - Toggle reset"]
+        #[inline]
+        pub fn tr(&mut self) -> _TRW<'_> {
+            _TRW { w: self }
+        }
         #[doc = "Bit 29 - Stall"]
         #[inline]
         pub fn s(&mut self) -> _SW<'_> {


### PR DESCRIPTION
Fix high-speed USB interrupt endpoints by configuring the periodic endpoint type and correctly initializing data toggles after a bus reset.